### PR TITLE
Reading multiple forcing NetCDF files instead of one (iss35)

### DIFF
--- a/Driver/MESH_Driver/MESH_driver.f90
+++ b/Driver/MESH_Driver/MESH_driver.f90
@@ -257,16 +257,19 @@ program RUNMESH
 !    NSL = shd%lc%IGND
 !    NML = shd%lc%NML
 
-    !> Initialize forcing files list, if provided
+    !> Initialize forcing files list, if provided.
     if (allocated(forcing_files_list)) then
-        !> Assign the position of the first forcing file to be read to `fpos`.
+
+        !> Assign the position of the first forcing file to be read.
         fpos = 1
+
         !> Read the forcing files and assign the first file in the list as
         !> the forcing file to be used for the initialization process.
-        call read_forcing_files_list(fpos=fpos, error_status=ierr)
+        call read_forcing_files_list(fpos = fpos, error_status = ierr)
+
         !> If there is any issues, abort.
         if (ierr /= 0) then
-            call print_error("Errors occurred reading the forcing files list.")
+            call print_error("An error occurred reading the forcing files list.")
             call program_abort()
         end if
     end if
@@ -957,8 +960,7 @@ program RUNMESH
     ENDDATE = .false.
     ENDDATA = .false.
 
-    !> Run the model for each time-step until the
-    !> end date or end of data is reached.
+    !> Run the model for each time-step until the end date or end of data is reached.
     do while (.not. ENDDATE .and. .not. ENDDATA)
 
         !> If hit the end of forcing data, switch to the next forcing dataset file.
@@ -970,12 +972,10 @@ program RUNMESH
         end if
 
         if (ENDDATA) then
+
             !> Switch to the next forcing data file.
             fpos = fpos + 1
-            call switch_forcing_file( &
-                fpos=fpos, &
-                ENDDATA=ENDDATA, &
-                error_status=ierr)
+            call switch_forcing_file(fpos = fpos, ENDDATA = ENDDATA, error_status = ierr)
             if (ierr /= 0) then
                 call reset_tab()
                 call print_error("Errors occurred switching the forcing data files.")
@@ -994,7 +994,6 @@ program RUNMESH
                 call print_error("Errors occurred opening the forcing files.")
                 call program_abort()
             end if
-
         end if ! if (ENDDATA) then
 
         !> Reset output variables.

--- a/Driver/MESH_Driver/MESH_driver.f90
+++ b/Driver/MESH_Driver/MESH_driver.f90
@@ -257,6 +257,20 @@ program RUNMESH
 !    NSL = shd%lc%IGND
 !    NML = shd%lc%NML
 
+    !> Initialize forcing files list, if provided
+    if (allocated(forcing_files_list)) then
+        !> Assign the position of the first forcing file to be read to `fpos`.
+        fpos = 1
+        !> Read the forcing files and assign the first file in the list as
+        !> the forcing file to be used for the initialization process.
+        call read_forcing_files_list(fpos=fpos, error_status=ierr)
+        !> If there is any issues, abort.
+        if (ierr /= 0) then
+            call print_error("Errors occurred reading the forcing files list.")
+            call program_abort()
+        end if
+    end if
+
     !> Initialize climate forcing module.
     if (ro%RUNCLIM) then
         call open_input_forcing_files(ierr)

--- a/Driver/MESH_Driver/read_run_options.f90
+++ b/Driver/MESH_Driver/read_run_options.f90
@@ -10,7 +10,12 @@ subroutine READ_RUN_OPTIONS(fls, shd, ierr)
     use date_utilities, only: jday_to_date
 
     use FLAGS
-    use input_forcing, only: parse_basinforcingflag, forcing_file_hourly_flag_override, forcing_file_temporal_interpolation
+    use input_forcing, only: &
+        parse_basinforcingflag, &
+        forcing_file_hourly_flag_override, &
+        forcing_file_temporal_interpolation, &
+        forcing_files_list
+
     use save_basin_output, only: &
         BASINAVGWBFILEFLAG, BASINAVGEBFILEFLAG, BASINAVGEVPFILEFLAG, BASINSWEOUTFLAG, STREAMFLOWOUTFLAG, REACHOUTFLAG
     use RUNCLASS36_variables
@@ -375,6 +380,12 @@ subroutine READ_RUN_OPTIONS(fls, shd, ierr)
                     call parse_basinforcingflag(trim(line), error_status = z)
                 case ('BASINRECHARGEFLAG')
                     call parse_basinforcingflag(trim(line), error_status = z)
+                !> forcing_files_list is defined in the `input_forcing.f90` module file.
+                case ('FORCINGLIST')
+                    if (.not. allocated(forcing_files_list)) then
+                        allocate(forcing_files_list(1))
+                        forcing_files_list%list_file%full_path = trim(adjustl(args(2))) // '.txt'
+                    end if
 
                 case ('STREAMFLOWFILEFLAG')
                     fms%stmg%qomeas%fls%ffmt = adjustl(args(2))

--- a/Driver/MESH_Driver/read_run_options.f90
+++ b/Driver/MESH_Driver/read_run_options.f90
@@ -380,8 +380,9 @@ subroutine READ_RUN_OPTIONS(fls, shd, ierr)
                     call parse_basinforcingflag(trim(line), error_status = z)
                 case ('BASINRECHARGEFLAG')
                     call parse_basinforcingflag(trim(line), error_status = z)
-                !> forcing_files_list is defined in the `input_forcing.f90` module file.
                 case ('FORCINGLIST')
+
+                    !> 'forcing_files_list' is defined in 'input_forcing' module.
                     if (.not. allocated(forcing_files_list)) then
                         allocate(forcing_files_list(1))
                         forcing_files_list%list_file%full_path = trim(adjustl(args(2))) // '.txt'

--- a/Modules/io_modules/file_types.f90
+++ b/Modules/io_modules/file_types.f90
@@ -99,6 +99,7 @@ module file_types
         integer :: freq_interval = 0
         integer :: istep = 1
         type(io_datetime) start
+        type(io_datetime) end
         real :: time_offset = 0.0
         integer :: block_interval = 1
         integer :: iblock = 1
@@ -160,6 +161,19 @@ module file_types
         character(len = SHORT_FIELD_LENGTH), dimension(:, :), allocatable :: field_map
         type(field_overrides) overrides
         class(*), allocatable :: container
+    end type
+
+    !> Description:
+    !>  File list structure.
+    !>
+    !> Variables:
+    !*  ipos: Current position in the file list (start: 1).
+    !*  number_of_files: Number of files in the list.
+    type file_list
+        type(file_info) current_forcing_file
+        type(file_info) list_file
+        integer :: ipos = 0
+        integer :: number_of_files = 0
     end type
 
 end module

--- a/Modules/io_modules/input_forcing.f90
+++ b/Modules/io_modules/input_forcing.f90
@@ -1317,7 +1317,9 @@ module input_forcing
     subroutine switch_forcing_file(fpos, ENDDATA, error_status)
 
         !> Modules.
+#ifdef NETCDF
         use nc_io
+#endif
 
         !> Input/output variables.
         !* ENDDATA: Flag indicating if the end of data has been reached
@@ -1345,6 +1347,7 @@ module input_forcing
             if (error_status /= 0) return
 
             !> Necessary preparations for switching files.
+#ifdef NETCDF
             do i = 1, size(forcing_files)
 
                 !> Close the previously opened file.
@@ -1356,6 +1359,12 @@ module input_forcing
                     forcing_files(i)%series%ipos = 1
                 end if
             end do
+#else
+
+            !> Print an error and abort if NetCDF is not enabled.
+            call print_error("A version of MESH compiled with the NetCDF library must be used to support 'FORCINGLIST'.")
+            call program_abort()
+#endif
         end if
 
         if (error_status /= 0) then

--- a/Modules/io_modules/input_forcing.f90
+++ b/Modules/io_modules/input_forcing.f90
@@ -5,6 +5,9 @@ module input_forcing
 
     implicit none
 
+    !* forcing_files_list: list of forcing files
+    type(file_list), dimension(:), allocatable, save :: forcing_files_list
+
     !* forcing_files: List of forcing files (of type 'io_file', private).
     type(io_file), dimension(:), allocatable, private, save :: forcing_files
 
@@ -1101,5 +1104,254 @@ module input_forcing
         end do
 
     end subroutine
+
+    subroutine read_forcing_files_list(fpos, error_status)
+        !> This subroutine reads a list of forcing files from a specified
+        !> position in the list file.
+
+        !> Modules.
+        use model_dates, only: ic
+        use strings, only: writenum
+
+        !> Input/output variables.
+        integer, intent(out) :: error_status
+        integer, intent(in) :: fpos
+
+        !> Local variables.
+        integer i, j
+        character(len=2000) :: temp_line
+        character(len=8) :: lineno
+
+        !> Status.
+        error_status = 0
+
+        !> Check if a list of forcing files are provided
+        if (allocated(forcing_files_list)) then
+            !> If ipos and number_of_files are set to zero, initialize the process.
+            if (forcing_files_list(1)%ipos == 0 .and. forcing_files_list(1)%number_of_files == 0) then
+                !> Set the position of file counter to 1
+                forcing_files_list(1)%ipos = 1
+
+                !> Print a message about using the forcing files list.
+                call print_message("READING: " // trim(forcing_files_list(1)%list_file%full_path))
+
+                !> Open the forcing files list.
+                open (&
+                    newunit = forcing_files_list(1)%list_file%iunit, &
+                    file = forcing_files_list(1)%list_file%full_path, &
+                    status = 'old', &
+                    action = 'read', &
+                    iostat = error_status)
+                !> If the file could not be opened, print an error message and return.
+                if (error_status /= 0) then
+                    call print_error("Cannot open the forcing files list: " // trim(forcing_files_list(1)%list_file%full_path))
+                    return
+                end if
+
+                !> Count the total number of lines in the file and assign it to the number_of_files variable.
+                rewind(forcing_files_list(1)%list_file%iunit)
+                forcing_files_list(1)%number_of_files = 0
+                do
+                    read(forcing_files_list(1)%list_file%iunit, '(A)', iostat = error_status) temp_line
+                    if (error_status /= 0) exit
+                    forcing_files_list(1)%number_of_files = forcing_files_list(1)%number_of_files + 1
+                end do
+
+            end if
+
+            !> Make sure `ipos` is always smaller than `number_of_files`
+            if (forcing_files_list(1)%ipos > forcing_files_list(1)%number_of_files) then
+                call print_error("The current position in the forcing files list exceeds the number of files.")
+                error_status = 1
+                return
+            end if
+
+            !> If reading is successful, read the first line to get the file name.
+            !> Read a specific line number from the file
+
+            !> Revert back to the first line of the forcing files list.
+            rewind(forcing_files_list(1)%list_file%iunit)
+
+            !> Based on the `fpos` target line number, read the file until the
+            !> target line is reached.
+            !> Special case: if `ipos` and `fpos` are both 1, read the first line.
+            if (forcing_files_list(1)%ipos == 1 .and. fpos == 1) then
+                read(forcing_files_list(1)%list_file%iunit, '(A)', iostat = error_status) temp_line
+                if (error_status /= 0) then
+                    call print_error("Error reading the forcing files list at line 1")
+                    return
+                end if
+                !> Set the position to 1 since we are reading the first line.
+                forcing_files_list(1)%ipos = 1
+            else
+                do while (forcing_files_list(1)%ipos <= fpos)
+                    !> Read the next line from the file.
+                    read(forcing_files_list(1)%list_file%iunit, '(A)', iostat = error_status) temp_line
+                    if (error_status /= 0) then
+                        call writenum(forcing_files_list(1)%ipos, lineno, 'I0')
+                        call print_error("Error reading the forcing files list at line " // trim(adjustl(lineno)))
+                        return
+                    end if
+                    !> Set the position to the current line.
+                    forcing_files_list(1)%ipos = forcing_files_list(1)%ipos + 1
+                end do
+            end if
+
+            if (error_status == 0) then
+                forcing_files_list(1)%current_forcing_file%full_path = trim(temp_line)
+            end if
+
+            !> Print progress
+            call print_message( &
+                message="Assigning '" // trim(forcing_files_list(1)%current_forcing_file%full_path) // "' as the forcing file.", &
+                level=2)
+
+            !> Change the path names in forcing_files to the
+            !> `current_forcing_file` in the list.
+            if (allocated(forcing_files)) then
+                if (size(forcing_files) > 0) then
+                    !> Iterate through the forcing files array.
+                    do i = 1, size(forcing_files)
+                        !> Rename the forcing file to the first file in the list.
+                        forcing_files(i)%file_info%full_path = forcing_files_list(1)%current_forcing_file%full_path
+                    end do
+                end if
+            else
+                call print_error("Forcing files array is not allocated properly.")
+                error_status = 1
+                return
+            end if !> if allocated(forcing_files)
+
+        else
+            !> Print an error message if the forcing files list is not allocated.
+            call print_error("Forcing files list is not allocated. Please check the input configurations.")
+            error_status = 1
+            return
+
+        end if !> if allocated(forcing_files_list)
+
+    end subroutine read_forcing_files_list
+
+    subroutine check_forcing_data_end(ENDDATA, error_status)
+        !> This subroutine checks if the end of data has been reached in any
+        !> forcing file. If the current model time exceeds the end time of any
+        !> forcing file, it sets the ENDDATA flag to .true. and returns.
+
+        !> Modules.
+        use date_utilities, only: date_components_to_time
+        use model_dates, only: ic
+
+        !> Input/output variables.
+        !*  ENDDATA: Flag indicating if the end of data has been reached
+        !*    in any forcing file (.false.: not reached).
+        !*  error_status: Status returned by the operation (optional; 0: normal).
+        logical, intent(inout) :: ENDDATA
+        integer, intent(out) :: error_status
+
+        !* time variables.
+        real(kind=kind(0.0d0)) :: forcing_file_end_time
+        real(kind=kind(0.0d0)) :: now_time
+
+        !> Local variables.
+        integer i
+
+        !> Status.
+        error_status = 0
+
+        !> Check if the end of data has been reached in any forcing file.
+        do i = 1, size(forcing_files)
+            !> Forcing file end time in JDN.
+            forcing_file_end_time = date_components_to_time( &
+                forcing_files(i)%series%end%year, &
+                forcing_files(i)%series%end%month, &
+                forcing_files(i)%series%end%day, &
+                forcing_files(i)%series%end%hour, &
+                forcing_files(i)%series%end%minutes, &
+                error_status = error_status)
+
+            !> Check for errors in time conversion.
+            if (error_status /= 0) then
+                call print_error("An error occurred getting the end time of the forcing file in JDN.")
+                return
+            end if
+
+            !> Current time-step in JDN time.
+            now_time = date_components_to_time( &
+                ic%now%year, &
+                ic%now%month, &
+                ic%now%day, &
+                ic%now%hour, &
+                ic%now%mins, &
+                error_status = error_status)
+
+            !> Check for errors in time conversion.
+            if (error_status /= 0) then
+                call print_error("An error occurred getting the current model's time-step in JDN.")
+                return
+            end if
+
+            !> Check the end of data for the forcing file.
+            if (now_time > forcing_file_end_time) then
+                !> Indicate the end of data has been reached.
+                ENDDATA = .true.
+                exit
+            end if
+        end do
+
+    end subroutine check_forcing_data_end
+
+    subroutine switch_forcing_file(fpos, ENDDATA, error_status)
+        !> This subroutine switches to the next forcing file in the list.
+        !> If the position exceeds the number of files, it sets ENDDATA to .true.
+        !> and returns without reading a new file.
+
+        !> Modules.
+        use nc_io
+
+        !> Input/output variables.
+        !* ENDDATA: Flag indicating if the end of data has been reached
+        !* fpos: Position in the forcing files list to switch to.
+        !* error_status: Status returned by the operation (optional; 0: normal).
+        logical, intent(inout) :: ENDDATA
+        integer, intent(in) :: fpos
+        integer, intent(out) :: error_status
+
+        !> Local variables.
+        integer i
+
+        !> Status.
+        error_status = 0
+
+        !> If fpos turns out to be greater than number_of_files, set the ENDDATA to .true. and return.
+        if (fpos > forcing_files_list(1)%number_of_files) then
+            call print_warning("Reached the end of the forcing files list. No more files to read.")
+            ENDDATA = .true.
+            return
+        else
+            !> Read the next forcing file from the list.
+            call read_forcing_files_list(fpos, error_status)
+            if (error_status /= 0) return
+
+            !> Necessary preparations for switching files.
+            do i = 1, size(forcing_files)
+                !> Close the previously opened file.
+                call nc4_close_file(forcing_files(i)%file_info%iunit, forcing_files(i)%file_info%full_path, ierr = error_status)
+                !> Empty the fields from the forcing files as well as setting ipos to 1.
+                if (allocated(forcing_files(i)%fields)) then
+                    deallocate(forcing_files(i)%fields)
+                    forcing_files(i)%series%ipos = 1
+                end if
+            end do
+        end if
+
+        if (error_status /= 0) then
+            call print_error("An error occurred while switching forcing files.")
+            return
+        end if
+
+        !> Reset ENDDATA to .false. to resume reading.
+        if (ENDDATA) ENDDATA = .false.
+
+    end subroutine switch_forcing_file
 
 end module

--- a/Modules/io_modules/mesh_io.F90
+++ b/Modules/io_modules/mesh_io.F90
@@ -1256,11 +1256,24 @@ module mesh_io
                                 error_status = 1
                                 return
                             else
+                                !> Derive the start-time (from the first record of the 'time' variable).
                                 call nc4_get_time( &
                                     input_file%iunit, &
                                     year = input_file%series%start%year, month = input_file%series%start%month, &
                                     day = input_file%series%start%day, jday = input_file%series%start%jday, &
                                     hour = input_file%series%start%hour, minutes = input_file%series%start%minutes, &
+                                    time_shift = input_file%series%time_offset, &
+                                    ierr = ierr)
+                                if (ierr /= 0) then
+                                    error_status = 1
+                                    return
+                                end if
+                                ! > Derive the end-time (from the last record of the 'time' variable).
+                                call nc4_get_time_last( &
+                                    input_file%iunit, &
+                                    year = input_file%series%end%year, month = input_file%series%end%month, &
+                                    day = input_file%series%end%day, jday = input_file%series%end%jday, &
+                                    hour = input_file%series%end%hour, minutes = input_file%series%end%minutes, &
                                     time_shift = input_file%series%time_offset, &
                                     ierr = ierr)
                                 if (ierr /= 0) then

--- a/Modules/io_modules/mesh_io.F90
+++ b/Modules/io_modules/mesh_io.F90
@@ -1256,7 +1256,8 @@ module mesh_io
                                 error_status = 1
                                 return
                             else
-                                !> Derive the start-time (from the first record of the 'time' variable).
+
+                                !> Get the start-time from the first record of the 'time' variable.
                                 call nc4_get_time( &
                                     input_file%iunit, &
                                     year = input_file%series%start%year, month = input_file%series%start%month, &
@@ -1268,7 +1269,8 @@ module mesh_io
                                     error_status = 1
                                     return
                                 end if
-                                ! > Derive the end-time (from the last record of the 'time' variable).
+
+                                !> Get the end-time from the last record of the 'time' variable.
                                 call nc4_get_time_last( &
                                     input_file%iunit, &
                                     year = input_file%series%end%year, month = input_file%series%end%month, &

--- a/Modules/io_modules/nc_io.F90
+++ b/Modules/io_modules/nc_io.F90
@@ -396,8 +396,7 @@ module nc_io
             ierr = 1
         else
 
-            !> Calculate the reference datetime in hours.
-            !> Converting Gregorian calendar date to Julian Day Number (JDN) 
+            !> Calculate the reference datetime in hours from Gregorian calendar date to Julian Day Number (JDN).
             nc4_time_from_date_components = &
                 real( &
                     (1461*(year + 4800 + (month - 14)/12))/4 + (367*(month - 2 - 12*((month - 14)/12)))/12 - &
@@ -698,6 +697,7 @@ module nc_io
             return
         end if
 
+        !> The last index is the length of the dimension.
         last_idx = dimlen
 
         !> Allocate array to read the last value.
@@ -732,7 +732,6 @@ module nc_io
         call nc4_date_components_from_time(t1_r8(1), year, month, day, jday, hour, minutes, seconds, ierr)
 
     end subroutine
-
 
     logical function nc4_inquire_attribute(iun, attribute_name, vid)
 

--- a/Modules/io_modules/nc_io.F90
+++ b/Modules/io_modules/nc_io.F90
@@ -397,6 +397,7 @@ module nc_io
         else
 
             !> Calculate the reference datetime in hours.
+            !> Converting Gregorian calendar date to Julian Day Number (JDN) 
             nc4_time_from_date_components = &
                 real( &
                     (1461*(year + 4800 + (month - 14)/12))/4 + (367*(month - 2 - 12*((month - 14)/12)))/12 - &
@@ -634,6 +635,104 @@ module nc_io
         call nc4_date_components_from_time(t1_r8(1), year, month, day, jday, hour, minutes, seconds, ierr)
 
     end subroutine
+
+    subroutine nc4_get_time_last( &
+        iun, &
+        tid, reference_time, units, name_time, time_shift, &
+        year, month, day, jday, hour, minutes, seconds, &
+        ierr)
+
+        !> Input variables.
+        integer, intent(in) :: iun
+
+        !> Input variables (optional).
+        integer, intent(in), optional :: tid
+        real(kind = EightByteReal), intent(in), optional :: reference_time
+        character(len = *), intent(in), optional :: units
+        character(len = *), intent(in), optional :: name_time
+        real, intent(in), optional :: time_shift
+
+        !> Output variables (optional).
+        integer, intent(out), optional :: year, month, day, jday, hour, minutes, seconds
+
+        !> Output variables.
+        integer, intent(out) :: ierr
+
+        !> Local variables.
+        character(len = DEFAULT_FIELD_LENGTH) vname, vunits, field, code
+        integer i, vid, dimids(NF90_MAX_VAR_DIMS), ndims, dimlen, last_idx
+        real(kind = EightByteReal), allocatable :: t1_r8(:)
+        real(kind = EightByteReal) t0
+
+        !> Set the variable name.
+        if (present(name_time)) then
+            vname = trim(name_time)
+        else
+            vname = 'time'
+        end if
+
+        !> Get the reference time and variables (if not provided).
+        if (.not. present(tid) .or. .not. present(reference_time) .or. .not. present(units)) then
+            call nc4_get_reference_time(iun, vname, time_shift, tid = vid, units = vunits, reference_time = t0, ierr = ierr)
+            if (ierr /= 0) return
+        end if
+
+        !> Assign optional variables.
+        if (present(tid)) vid = tid
+        if (present(units)) vunits = units
+        if (present(reference_time)) t0 = reference_time
+
+        !> Get dimension info for the time variable.
+        ierr = nf90_inquire_variable(iun, vid, ndims = ndims, dimids = dimids)
+        if (ierr /= NF90_NOERR .or. ndims < 1) then
+            call print_error("Unable to get time variable dimensions.")
+            ierr = 1
+            return
+        end if
+
+        !> Get the length of the time dimension (assume first dimension is time).
+        ierr = nf90_inquire_dimension(iun, dimids(1), len = dimlen)
+        if (ierr /= NF90_NOERR) then
+            call print_error("Unable to get time dimension length.")
+            ierr = 1
+            return
+        end if
+
+        last_idx = dimlen
+
+        !> Allocate array to read the last value.
+        allocate(t1_r8(1))
+
+        !> Read the last time value.
+        ierr = nf90_get_var(iun, vid, t1_r8, start = (/last_idx/), count = (/1/))
+        if (ierr /= 0) return
+
+        !> Add the value to the reference time (converting to units of 'hours').
+        i = index(vunits, 'since')
+        if (i > 1) then
+            select case (vunits(1:(i - 1)))
+                case ('seconds')
+                    t1_r8 = t0 + t1_r8/24.0/60.0/60.0
+                case ('minutes')
+                    t1_r8 = t0 + t1_r8/24.0/60.0
+                case ('hours')
+                    t1_r8 = t0 + t1_r8/24.0
+                case ('days')
+                    t1_r8 = t0 + t1_r8
+                case default
+                    call print_error( &
+                        "Unsupported units for the '" // trim(vname) // "' variable. " // &
+                        "The units should be in the format: [seconds/minutes/hours/days] since yyyy/MM/dd HH:mm:ss[.SSSSSS]")
+                    ierr = 1
+                    return
+            end select
+        end if
+
+        !> Calculate the components.
+        call nc4_date_components_from_time(t1_r8(1), year, month, day, jday, hour, minutes, seconds, ierr)
+
+    end subroutine
+
 
     logical function nc4_inquire_attribute(iun, attribute_name, vid)
 


### PR DESCRIPTION
This pull request introduces significant enhancements to the handling of forcing data files in the MESH model, including support for switching between multiple forcing files during runtime. Key changes include the addition of new subroutines, updates to existing modules, and improvements to error handling and file metadata management.

### Enhancements to Forcing Data File Handling:
* **Support for Multiple Forcing Files**: Introduced a new `file_list` type in `Modules/io_modules/file_types.f90` to manage a list of forcing files, including metadata like current position and total number of files. [Modules/io_modules/file_types.f90R166-R178]

* **Dynamic Forcing File Switching**: Added subroutines `read_forcing_files_list`, `check_forcing_data_end`, and `switch_forcing_file` in `Modules/io_modules/input_forcing.f90` to dynamically read and switch forcing files during runtime. 

* **End-Time Metadata**: Enhanced `read_file_fields_to_buffer` in `Modules/io_modules/mesh_io.F90` to derive and store the end-time of forcing files using a new subroutine `nc4_get_time_last`.

### Updates to Input Handling:
* **New FORCINGLIST Option**: Updated `Driver/MESH_Driver/read_run_options.f90` to parse a new `FORCINGLIST` option, allowing users to specify a list of forcing files via a configuration file. 

* **Allocation of Forcing Files List**: Added a new `forcing_files_list` variable in `Modules/io_modules/input_forcing.f90`, which stores the list of forcing files for runtime operations.

### Improvements to File Metadata Management:
* **End-Time Calculation**: Introduced `nc4_get_time_last` in `Modules/io_modules/nc_io.F90` to retrieve the last time record from NetCDF files, ensuring accurate tracking of forcing file boundaries.

* **Julian Day Number Conversion**: Added comments to clarify the Julian Day Number (JDN) conversion logic in `nc4_time_from_date_components`.

### Runtime Logic Enhancements:
* **Time-Step Execution Loop**: Modified `Driver/MESH_Driver/MESH_driver.f90` to include logic for checking and switching forcing files at the end of data, ensuring seamless transitions between files.

* **Initialization of Forcing File Position**: Added a new variable `fpos` in `Driver/MESH_Driver/MESH_driver.f90` to track the current position in the forcing file list.

### Typical change to `MESH_input_run_options.ini`
A typical `.ini` file can look like the following:

```ini
  1 MESH input run options file                             # comment line 1                                | *
  2 ##### Control Flags #####                               # comment line 2                                | *
  3 ----#                                                   # comment line 3                                | *
  4    42                                                   # Number of control flags                       | I5
  5 BASINFORCINGFLAG       nc_subbasin start_date=19800101 hf=60 time_shift=-6
  6 BASINSHORTWAVEFLAG     name_var=RDRS_v2.1_P_FB_SFC
  7 BASINHUMIDITYFLAG      name_var=RDRS_v2.1_P_HU_09944
  8 BASINRAINFLAG          name_var=RDRS_v2.1_A_PR0_SFC
  9 BASINPRESFLAG          name_var=RDRS_v2.1_P_P0_SFC
 10 BASINLONGWAVEFLAG      name_var=RDRS_v2.1_P_FI_SFC
 11 BASINWINDFLAG          name_var=RDRS_v2.1_P_UVC_09944
 12 BASINTEMPERATUREFLAG   name_var=RDRS_v2.1_P_TT_09944
 13 FORCINGLIST            forcing_files_list
 14 TIMESTEPFLAG           60
 15 INPUTPARAMSFORMFLAG    txt
 16 IDISP                  0                                #02 Vegetation Displacement Height Calculation  | A20, I4
...
```

As is obvious, the `fname=` value for the `BASINFORCINGFLAG` is optional (if provided, is ignored), and the `FORCINGLIST` option reads the `forcing_files_list.txt` file detailing order NetCDF files to be read by the model. 

Here is an example of file that can be read by `FORCINGLIST` option:
```
1980.nc
1981.nc
1982.nc
```

This PR fixes #35.