### PR TITLE
Style changes and bugfix for CLASS `uvcan` (`VAC`)

### DIFF
--- a/Driver/MESH_Driver/read_parameters.f90
+++ b/Driver/MESH_Driver/read_parameters.f90
@@ -612,7 +612,7 @@ subroutine read_parameters(fls, shd, ierr)
         end where
 
         !> Check for impermeable soils
-        !> ME changed the accurcy threshold from 0.001 to be the same as in CLASSB/BG.
+        !> ME changed the accuracy threshold from 0.001 to be the same as in CLASSB/BG.
         do j = 2, shd%lc%IGND
             where (pm%tile%sdep < (shd%lc%sl%ZBOT(j - 1) + 0.025) .and. pm%tile%sand(:, j) > -2.5)
                 pm%tile%sand(:, j) = -3.0

--- a/LSS_Model/CLASS/3.6/sa_mesh_process/RUNCLASS36_module.f90
+++ b/LSS_Model/CLASS/3.6/sa_mesh_process/RUNCLASS36_module.f90
@@ -95,6 +95,7 @@ module RUNCLASS36_module
 
             !> Grab states.
             cpv%QAC(il1:il2) = vs%tile%qacan(il1:il2)
+            cpv%VAC(il1:il2) = vs%tile%uvcan(il1:il2)
             cpv%RCAN(il1:il2) = vs%tile%lqwscan(il1:il2)
             cpv%SNCAN(il1:il2) = vs%tile%fzwscan(il1:il2)
             cpv%TAC(il1:il2) = vs%tile%tacan(il1:il2)
@@ -355,7 +356,7 @@ module RUNCLASS36_module
             !>  THIS IS TARGETTED AS OVERLAND RUNOFF.
             !> Ported from CLASS 3.6.2.
             do i = il1, il2
-                if (ZSNOW(i) .GT. 10.0) then
+                if (ZSNOW(i) > 10.0) then
                     SNOROF = (ZSNOW(i) - 10.0)*cpv%RHOS(i)
                     WSNROF = cpv%WSNO(i)*SNOROF/cpv%SNO(i)
                     cdv%TROO(i) = &

--- a/Modules/mountain_module/forcing_adjust.f90
+++ b/Modules/mountain_module/forcing_adjust.f90
@@ -325,7 +325,7 @@ subroutine forcing_adjust( &
         do k = 1, nvals
             temp_frac(k) = temp(k)/grid_sum_temp(nml_grid_map(k))
         end do
-        if (itemp .ne. 0) then
+        if (itemp /= 0) then
             temp_adjusted = temp_adjusted*temp_frac
         end if
     end if

--- a/Routing_Model/RPN_watroute/code/flowinit.f
+++ b/Routing_Model/RPN_watroute/code/flowinit.f
@@ -890,7 +890,7 @@ c      stop 'program aborted in flowinit @ 164'
 !        FLOW MAY HAVE BEEN ROUTED DOWN A TRIBUTARY OR
 !        THERE IS A GAUGE DOWNSTREAM
             nnx=next(n)
-            if(nnx.eq.0) cycle
+            if(nnx.eq.0)cycle
 
             msg1='a'
             if(iopt.ge.2)then
@@ -1169,7 +1169,7 @@ c      stop 'program aborted in flowinit @ 164'
 !mesh_io      write(51,9801)dacheck
 
       do n=1,naa
-         if (da(n).eq.0.0) cycle
+         if(da(n).eq.0.0)cycle
          i=yyy(n)
          j=xxx(n)
          ii=ibn(n)


### PR DESCRIPTION
Style changes and bugfix in CLASS transferring `uvcan` to `VAC` at the beginning of the time-step, missed in 14b0ff732550c695f6b875fc13648e0ece3d0a93.