### PR TITLE
feat(mesh): Added option `pad_outlets` to `SHDFILEFLAG`

### DIFF
--- a/Driver/MESH_Driver/read_initial_inputs.f90
+++ b/Driver/MESH_Driver/read_initial_inputs.f90
@@ -75,6 +75,7 @@ subroutine READ_INITIAL_INPUTS(fls, shd, release, ierr)
     !> Assign default configuration
     SHDFILEFMT = 1
     SHDTOMAPFLAG = .false.
+    SHDPADOUTLETS = .false.
 
     !> Parse 'SHDFILEFLAG'.
     call parse(SHDFILEFLAG, ' ', args, n)
@@ -93,6 +94,8 @@ subroutine READ_INITIAL_INPUTS(fls, shd, release, ierr)
                     SHDFILEFMT = 5
                 case ('to_map')
                     SHDTOMAPFLAG = .true.
+                case ('pad_outlets')
+                    SHDPADOUTLETS = .true.
             end select
         end do
     end if

--- a/Driver/MESH_Driver/shd_variables.f90
+++ b/Driver/MESH_Driver/shd_variables.f90
@@ -216,4 +216,7 @@ module shd_variables
     !* SHDTOMAPFLAG: Option to create a WATFLOOD 'map' file from the drainage database.
     logical, save  :: SHDTOMAPFLAG = .false.
 
+    !* SHDPADOUTLETS: Option to add an extra subbasin or cell and pad all in-basin outlets.
+    logical, save :: SHDPADOUTLETS = .false.
+
 end module


### PR DESCRIPTION
Outlets will be padded to the network read from the drainage database if `pad_outlets` is specified on `SHDFILEFLAG`. This can allow streamflow to be output for the last cell or subbasin in a channel segment when no 'dummy' outlet is specified through the process of creating the drainage database file (e.g., if no artificial outlet is added, as would be the case for drainage databases created using GreenKenue).