### PR TITLE
fix(io): Resolves an error that could occur with seeking past the header in r2c-format files

### DIFF
--- a/Modules/io_modules/ensim_io.f90
+++ b/Modules/io_modules/ensim_io.f90
@@ -941,9 +941,11 @@ module ensim_io
         !> Local variables.
         character(len = MAX_LINE_LENGTH) line
 
+        !> Set the error status.
+        ierr = 0
+
         !> Rewind to the beginning of the file, then read until the end of the EnSim header.
         rewind(iun)
-        ierr = 0
         do while (ierr == 0)
             call read_ensim_line(iun, line, ierr)
             if (ierr /= 0) exit


### PR DESCRIPTION
When compiled using optimizations with `gcc13` and possibly `gcc12`-`14`, a bad `iostat` is returned or `ierr` seems to not hold a non-zero value, which causes the routine to exit without properly seeking the file. This causes warnings that eventually lead to the file being improperly dimensioned for time-based r2c-format files. Moving the initialization/zeroing of the `ierr` output variable before the call to `rewind` the file seems to resolve this issue in optimized code. This issue would not be encountered when compiled using `debug` symbols and was not present when using older `gcc` versions (e.g., `gcc5`-`11`).

Resolves issue #94.