### PR TITLE
fix(io): MESH-Model/MESH-Dev#11

### DIFF
--- a/Modules/io_modules/basin_utilities.f90
+++ b/Modules/io_modules/basin_utilities.f90
@@ -696,13 +696,25 @@ module basin_utilities
             allocate(shd%IROUGH(vs%grid%dim_length))
             shd%IROUGH = 0
         end if
-        allocate(shd%ELEV(vs%grid%dim_length))
-        shd%ELEV = 0.0
+        if (allocated(vs%grid%topo_elev)) then
+            allocate(shd%ELEV(vs%grid%dim_length), source = vs%grid%topo_elev)
+        else
+            allocate(shd%ELEV(vs%grid%dim_length))
+            shd%ELEV = 0.0
+        end if
+!        if (allocated(vs%grid%topo_slope)) then
+!            allocate(shd%SLOPE_INT(vs%grid%dim_length), source = vs%grid%topo_slope)
+!        end if
         shd%AL = pj%nominal_side_length
         allocate(shd%xlng(vs%grid%dim_length), source = vs%grid%lon)
         allocate(shd%ylat(vs%grid%dim_length), source = vs%grid%lat)
         allocate(shd%xxx(vs%grid%dim_length), source = vs%grid%from_grid_x)
         allocate(shd%yyy(vs%grid%dim_length), source = vs%grid%from_grid_y)
+!        allocate(shd%RNKGRD(vs%grid_y, vs%grid_x))
+!        do y = 1, vs%grid_y
+!            shd%RNKGRD(y, :) = vs%grid%from_grid_xy(:, y)
+!        end do
+        allocate(shd%RNKGRD(vs%grid_y, vs%grid_x), source = transpose(vs%grid%from_grid_xy))
         allocate(shd%FRAC(vs%grid%dim_length), source = vs%grid%area_weight)
 !<<temp
 


### PR DESCRIPTION
Fixed the index out of bounds error when using the `to_map` option on `SHDFILEFLAG`. However, issues with deriving `FRAC` using the 'nominal side-length' may still cause issues, especially for larger basins, if the cell geometry should be derived on a per-lat/lon basis (not supported). When using the option, a sanity check against the existing db and one re-created by GreenKenue (GK) (from 'MESH_basin.map') should be done to ensure it recreates the expected `GridArea` values.

Re-enabled reading and writing the elevation field (via `topo_elev`), which is necessary for GK to index the file and accumulate drainage properties. Added but kept reading and writing the internal slope (via `topo_slope`) deactivated, as enabling it by default may cause parameterized values to be overwritten in 'read_parameters', and the `IROUGH` field derived from it is not used.